### PR TITLE
Update to '@vercel/node' due to '@now/node' depreciation

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "builds": [
     {
       "src": "index.js",
-      "use": "@now/node"
+      "use": "@vercel/node"
     }
   ],
   "routes": [


### PR DESCRIPTION
# Description
Fix issue from Vercel build logs:
> Installing Builder: @now/node
WARN! npm WARN deprecated @now/node@1.8.5: "@now/node" is deprecated and will stop receiving updates on December 31, 2020. Please use "@vercel/node" instead.